### PR TITLE
refactor:improve policy matching of img name, tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ repositories:
       url: https://123123123123.dkr.ecr.ap-northeast-1.amazonaws.com
       organization: org_name
       images:
-      - name: "*|image*|image-*|*image"(*1)
+      - name: "*|image*|image-*|*image|!negative-*"(*1)
         policy:
           version: <= 0.1
           age: <= 10d (*2)
@@ -40,7 +40,7 @@ repositories:
       url: https://hub.docker.com
       organization: org_name
       images:
-      - name: "*|image*|image-*|*image"
+      - name: "*|image*|image-*|*image|!negative-*"
         policy:
           age: <= 60d
       credentials:
@@ -52,7 +52,7 @@ repositories:
       url: https://hub.docker.com
       organization: org_name
       images:
-      - name: "!negative"
+      - name: "!negative-*"
         policy:
           age: <= 60h
       credentials:

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -10,8 +10,8 @@ repositories:
           version: <= 0.1
           age: <= 10d
       credentials:
-        username: username
-        password: password
+        access_key_id: access_key_id
+        secret_access_key: secret_access_key
   - name: Docker Hub - examp2
     repository_type: DOCKER_HUB
     options:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests==2.26.0
 pyyaml==5.4.1
-docker_registry_client==0.5.2
 boto3==1.18.9
+packaging==21.0

--- a/src/connector/__init__.py
+++ b/src/connector/__init__.py
@@ -45,26 +45,27 @@ class BaseConnetor(ABC):
 
     def _filter(self, image_name, tags):
         image_rules = self.config['options']['images']
-
         image_policy = self._get_image_policy(image_name, image_rules)
         if image_policy is None:
             return []
 
-        tags_by_policy = self._get_tags_by_policy(image_policy,tags)
+        tags_by_policy = self._get_tags_by_policy(image_policy, tags)
 
         return tags_by_policy
 
     def _get_image_policy(self, image_name, image_rules):
         for rule in image_rules:
-            if is_negative_match := re.match('^!',rule['name']):
-                negative_match_pattern = is_negative_match.string[1:]
-                if re.match(f"(?!.*{negative_match_pattern}.*)",image_name):
-                    return rule['policy']
-            else:
-                if fnmatch.fnmatch(image_name,rule['name']):
-                    return rule['policy']
+            if self._check_image_policy(image_name, rule):
+                return rule['policy']
 
         return None
+
+    def _check_image_policy(self, image_name, rule):
+        is_negative_match = False
+        if rule['name'][:1] == "!":
+            is_negative_match = True
+
+        return fnmatch.fnmatch(image_name, rule['name']) == (not is_negative_match)
 
     def _get_tags_by_policy(self, image_policy, tags):
         age_policy = image_policy.get('age')
@@ -81,56 +82,62 @@ class BaseConnetor(ABC):
         for tag in tags:
             tag_version = tag.get('name')
             tag_last_pushed = tag.get('tag_last_pushed')
-            flags = []
             if tag_version == "latest":
                 continue
 
+            flags = []
             if version_policy:
-                if not re.fullmatch('^(=|>|<)=?\s[\d.]+',version_policy):
-                    raise Exception("Invalid version policy format")
-
-                version_policy_operator = version_policy.split(" ")[0]
-                version_policy_number = version_policy.split(" ")[1]
-                
-                if not ops.get(version_policy_operator):
-                    raise Exception("Unsupported operator")
-
-                try:
-                    comparison_tag_version = Version(tag_version)
-                    comparison_policy_version = Version(version_policy_number)
-                except InvalidVersion:
-                    flags.append(False)
-                else:
-                    version_filtering_flag = ops[version_policy_operator](comparison_tag_version, comparison_policy_version)
-                    flags.append(version_filtering_flag)
-
-            # TODO: refactoring to python dateparser
+                result = self._check_version_policy(version_policy, tag_version, ops)
+                flags.append(result)
             if age_policy:
-                if not re.fullmatch('^(=|>|<)=?\s\d+(d|h|m|s)',age_policy):
-                    raise Exception("Invalid age policy format")
-
-                age_policy_operator = age_policy.split(" ")[0]
-                age_policy_date = age_policy.split(" ")[1]
-                age_policy_date_variable = age_policy_date[-1]
-                age_policy_date_coefficient = int(age_policy_date[:-1])
-
-                if age_policy_date_variable == 'd':     # day
-                    coefficient = age_policy_date_coefficient * 1440
-                elif  age_policy_date_variable == 'h':  # hour
-                    coefficient = age_policy_date_coefficient * 60
-                elif age_policy_date_variable == 's':   # second
-                    coefficient = age_policy_date_coefficient / 60
-                else:
-                    raise Exception("Unsupported date format")
-
-                policy_date = datetime.now(tz=timezone.utc) - timedelta(minutes=coefficient)
-                if isinstance(tag_last_pushed, str):
-                    tag_last_pushed = datetime.strptime(tag_last_pushed, '%Y-%m-%dT%H:%M:%S.%f%z')
-                age_filtering_flag = ops[age_policy_operator](tag_last_pushed,policy_date)
-                flags.append(age_filtering_flag)
-
+                result = self._check_age_policy(age_policy, tag_last_pushed, ops)
+                flags.append(result)
             if False not in flags:
                 result.append(tag_version)
 
         return result
 
+    def _check_version_policy(self, version_policy, tag_version, ops):
+        p = r'(?P<operator>^(=|>|<|>=|<=))' \
+            r' (?P<number>[\d.]+)'
+        rule = re.compile(p)
+        policy = rule.match(version_policy)
+
+        if policy:
+            version_policy_operator = policy['operator']
+            version_policy_number = policy['number']
+        else:
+            raise Exception("Invalid version policy format")
+
+        try:
+            tag_version = Version(tag_version)
+            version_policy_number = Version(version_policy_number)
+        except InvalidVersion:
+            return False
+        else:
+            return ops[version_policy_operator](tag_version, version_policy_number)
+
+    def _check_age_policy(self, age_policy, tag_last_pushed, ops):
+        p = r'(?P<operator>(=|>|<|>=|<=))' \
+            r' (?P<date_number>\d+)' \
+            r'(?P<date_unit>(d|h|m|s)+)'
+        rule = re.compile(p)
+        policy = rule.match(age_policy)
+
+        if policy:
+            age_policy_operator = policy['operator']
+            age_policy_date_unit = policy['date_unit']
+            age_policy_date_number = int(policy['date_number'])
+        else:
+            raise Exception("Invalid age policy format")
+
+        if age_policy_date_unit == 'd':  # day
+            age_policy_date_number = age_policy_date_number * 1440
+        elif age_policy_date_unit == 'h':  # hour
+            age_policy_date_number = age_policy_date_number * 60
+        elif age_policy_date_unit == 's':  # second
+            age_policy_date_number = age_policy_date_number / 60
+
+        policy_date = datetime.now(tz=timezone.utc) - timedelta(minutes=age_policy_date_number)
+
+        return ops[age_policy_operator](tag_last_pushed, policy_date)

--- a/src/connector/__init__.py
+++ b/src/connector/__init__.py
@@ -85,19 +85,15 @@ class BaseConnetor(ABC):
             if tag_version == "latest":
                 continue
 
-            is_matched = []
-            if version_policy:
-                is_matched.append(self._check_version_policy(version_policy, tag_version, ops))
-
-            if age_policy:
-                is_matched.append(self._check_age_policy(age_policy, tag_last_pushed, ops))
-
-            if False not in is_matched:
+            if self._check_version_policy(version_policy, tag_version, ops) and self._check_age_policy(age_policy, tag_last_pushed, ops):
                 result.append(tag_version)
 
         return result
 
     def _check_version_policy(self, version_policy, tag_version, ops):
+        if not version_policy:
+            return True
+
         p = r'(?P<operator>^(=|>|<|>=|<=))' \
             r' (?P<number>\d+(?:\.\d+){1,2})'
         rule = re.compile(p)
@@ -124,6 +120,9 @@ class BaseConnetor(ABC):
         return ops[version_policy_operator](tag_version, version_policy_number)
 
     def _check_age_policy(self, age_policy, tag_last_pushed, ops):
+        if not age_policy:
+            return True
+
         p = r'(?P<operator>(=|>|<|>=|<=))' \
             r' (?P<date_number>\d+)' \
             r'(?P<date_unit>(d|h|m|s)+)'

--- a/src/connector/__init__.py
+++ b/src/connector/__init__.py
@@ -65,7 +65,7 @@ class BaseConnetor(ABC):
         if rule['name'][:1] == "!":
             is_negative_match = True
 
-        return fnmatch.fnmatch(image_name, rule['name']) == (not is_negative_match)
+        return fnmatch.fnmatch(image_name, rule['name'][1:]) == (not is_negative_match)
 
     def _get_tags_by_policy(self, image_policy, tags):
         age_policy = image_policy.get('age')
@@ -85,14 +85,14 @@ class BaseConnetor(ABC):
             if tag_version == "latest":
                 continue
 
-            flags = []
+            is_matched = []
             if version_policy:
-                result = self._check_version_policy(version_policy, tag_version, ops)
-                flags.append(result)
+                is_matched.append(self._check_version_policy(version_policy, tag_version, ops))
+
             if age_policy:
-                result = self._check_age_policy(age_policy, tag_last_pushed, ops)
-                flags.append(result)
-            if False not in flags:
+                is_matched.append(self._check_age_policy(age_policy, tag_last_pushed, ops))
+
+            if False not in is_matched:
                 result.append(tag_version)
 
         return result

--- a/src/connector/__init__.py
+++ b/src/connector/__init__.py
@@ -99,7 +99,7 @@ class BaseConnetor(ABC):
 
     def _check_version_policy(self, version_policy, tag_version, ops):
         p = r'(?P<operator>^(=|>|<|>=|<=))' \
-            r' (?P<number>[\d.]+)'
+            r' (?P<number>\d+(?:\.\d+){1,2})'
         rule = re.compile(p)
         policy = rule.match(version_policy)
 

--- a/src/connector/__init__.py
+++ b/src/connector/__init__.py
@@ -109,13 +109,19 @@ class BaseConnetor(ABC):
         else:
             raise Exception("Invalid version policy format")
 
-        try:
-            tag_version = Version(tag_version)
-            version_policy_number = Version(version_policy_number)
-        except InvalidVersion:
-            return False
+        p = '\d+(?:\.\d+){1,2}'
+        rule = re.compile(p)
+        split_tag_version = rule.match(tag_version)
+
+        if split_tag_version:
+            tag_version = split_tag_version.group()
         else:
-            return ops[version_policy_operator](tag_version, version_policy_number)
+            return False
+
+        tag_version = Version(tag_version)
+        version_policy_number = Version(version_policy_number)
+
+        return ops[version_policy_operator](tag_version, version_policy_number)
 
     def _check_age_policy(self, age_policy, tag_last_pushed, ops):
         p = r'(?P<operator>(=|>|<|>=|<=))' \

--- a/src/connector/dockerhub_connector.py
+++ b/src/connector/dockerhub_connector.py
@@ -1,4 +1,5 @@
 from . import BaseConnetor
+from datetime import datetime
 import requests
 import json
 import math
@@ -80,7 +81,7 @@ class DockerHubConnector(BaseConnetor):
             for result in response['results']:
                 tag = {}
                 tag['name'] = result['name']
-                tag['tag_last_pushed'] = result['tag_last_pushed']
+                tag['tag_last_pushed'] = datetime.strptime(result['tag_last_pushed'], '%Y-%m-%dT%H:%M:%S.%f%z')
                 tags.append(tag)
         
         return tags


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
- image negative match 개선
  - negative match(^!)의 경우 fnmatch의 return 값으로 false를 반환하는 경우에 image name filter를 pass하도록 수정
  - 일반 match/negative match를 판단하는 로직을 function 으로 분리 
- tag policy match 개선
  - re를 이용해 age/version policy의 format에 일치하는 tag를 판단할 수 있도록 수정
  - _get_tags_by_policy 내에 위치하던 판단 로직을 function으로 분리

https://github.com/spaceone-dev/image-cleaner/pull/7/files#diff-53e5f9cf2bae6e7494158002a9ff071bc3dc0376db41a214d979f7dda9dac107

### Known issue
