### PR TITLE
fix:modify return condition

### DIFF
--- a/src/connector/__init__.py
+++ b/src/connector/__init__.py
@@ -64,8 +64,9 @@ class BaseConnetor(ABC):
         is_negative_match = False
         if rule['name'][:1] == "!":
             is_negative_match = True
+            rule['name'] = rule['name'][1:]
 
-        return fnmatch.fnmatch(image_name, rule['name'][1:]) == (not is_negative_match)
+        return fnmatch.fnmatch(image_name, rule['name']) == (not is_negative_match)
 
     def _get_tags_by_policy(self, image_policy, tags):
         age_policy = image_policy.get('age')


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [x] Refactor
- [ ] etc

### Description
기존 `_check_image_policy`에서 이미지의 이름을 비교할때 무조건 맨 앞 문자열을 자르도록 되어있었습니다.

negative(!)로 policy를 설정한 경우 문제가 되지 않으나
일반 match policy로 설정한 경우, 문자열이 짤려 부정확한 match를 할 수 있기에 수정했습니다.

### Known issue
